### PR TITLE
use relative import

### DIFF
--- a/conformer/__init__.py
+++ b/conformer/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from conformer.model import Conformer
+from .model import Conformer

--- a/conformer/attention.py
+++ b/conformer/attention.py
@@ -19,8 +19,8 @@ import torch.nn.functional as F
 from torch import Tensor
 from typing import Optional
 
-from conformer.embedding import PositionalEncoding
-from conformer.modules import Linear
+from .embedding import PositionalEncoding
+from .modules import Linear
 
 
 class RelativeMultiHeadAttention(nn.Module):

--- a/conformer/convolution.py
+++ b/conformer/convolution.py
@@ -17,8 +17,8 @@ import torch.nn as nn
 from torch import Tensor
 from typing import Tuple
 
-from conformer.activation import Swish, GLU
-from conformer.modules import Transpose
+from .activation import Swish, GLU
+from .modules import Transpose
 
 
 class DepthwiseConv1d(nn.Module):

--- a/conformer/encoder.py
+++ b/conformer/encoder.py
@@ -17,13 +17,13 @@ import torch.nn as nn
 from torch import Tensor
 from typing import Tuple
 
-from conformer.feed_forward import FeedForwardModule
-from conformer.attention import MultiHeadedSelfAttentionModule
-from conformer.convolution import (
+from .feed_forward import FeedForwardModule
+from .attention import MultiHeadedSelfAttentionModule
+from .convolution import (
     ConformerConvModule,
     Conv2dSubampling,
 )
-from conformer.modules import (
+from .modules import (
     ResidualConnectionModule,
     Linear,
 )

--- a/conformer/feed_forward.py
+++ b/conformer/feed_forward.py
@@ -16,8 +16,8 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from conformer.activation import Swish
-from conformer.modules import Linear
+from .activation import Swish
+from .modules import Linear
 
 
 class FeedForwardModule(nn.Module):

--- a/conformer/model.py
+++ b/conformer/model.py
@@ -17,8 +17,8 @@ import torch.nn as nn
 from torch import Tensor
 from typing import Tuple
 
-from conformer.encoder import ConformerEncoder
-from conformer.modules import Linear
+from .encoder import ConformerEncoder
+from .modules import Linear
 
 
 class Conformer(nn.Module):


### PR DESCRIPTION
The import path is now absolute, which requires users to install or configuring the python path before using. However, this can be improved with relative import, so users can use the package without installing it first. 