### PR TITLE
Fix relative positional multi-head attention layer 

### DIFF
--- a/conformer/embedding.py
+++ b/conformer/embedding.py
@@ -18,25 +18,53 @@ import torch.nn as nn
 from torch import Tensor
 
 
-class PositionalEncoding(nn.Module):
+class RelPositionalEncoding(nn.Module):
     """
-    Positional Encoding proposed in "Attention Is All You Need".
-    Since transformer contains no recurrence and no convolution, in order for the model to make
-    use of the order of the sequence, we must add some positional information.
-
-    "Attention Is All You Need" use sine and cosine functions of different frequencies:
-        PE_(pos, 2i)    =  sin(pos / power(10000, 2i / d_model))
-        PE_(pos, 2i+1)  =  cos(pos / power(10000, 2i / d_model))
+    Relative positional encoding module.
+    Args:
+        d_model: Embedding dimension.
+        max_len: Maximum input length.
     """
-    def __init__(self, d_model: int = 512, max_len: int = 10000) -> None:
-        super(PositionalEncoding, self).__init__()
-        pe = torch.zeros(max_len, d_model, requires_grad=False)
-        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, d_model, 2).float() * -(math.log(10000.0) / d_model))
-        pe[:, 0::2] = torch.sin(position * div_term)
-        pe[:, 1::2] = torch.cos(position * div_term)
-        pe = pe.unsqueeze(0)
-        self.register_buffer('pe', pe)
 
-    def forward(self, length: int) -> Tensor:
-        return self.pe[:, :length]
+    def __init__(self, d_model: int = 512, max_len: int = 5000) -> None:
+        super(RelPositionalEncoding, self).__init__()
+        self.d_model = d_model
+        self.pe = None
+        self.extend_pe(torch.tensor(0.0).expand(1, max_len))
+
+    def extend_pe(self, x: Tensor) -> None:
+        if self.pe is not None:
+            if self.pe.size(1) >= x.size(1) * 2 - 1:
+                if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
+                return
+
+        pe_positive = torch.zeros(x.size(1), self.d_model)
+        pe_negative = torch.zeros(x.size(1), self.d_model)
+        position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32) * -(math.log(10000.0) / self.d_model)
+        )
+        pe_positive[:, 0::2] = torch.sin(position * div_term)
+        pe_positive[:, 1::2] = torch.cos(position * div_term)
+        pe_negative[:, 0::2] = torch.sin(-1 * position * div_term)
+        pe_negative[:, 1::2] = torch.cos(-1 * position * div_term)
+
+        pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
+        pe_negative = pe_negative[1:].unsqueeze(0)
+        pe = torch.cat([pe_positive, pe_negative], dim=1)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        Args:
+            x : Input tensor B X T X C
+        Returns:
+            torch.Tensor: Encoded tensor B X T X C
+        """
+        self.extend_pe(x)
+        pos_emb = self.pe[
+            :,
+            self.pe.size(1) // 2 - x.size(1) + 1 : self.pe.size(1) // 2 + x.size(1),
+        ]
+        return pos_emb


### PR DESCRIPTION
I referred to fairseq's conformer layer multi-head attention. [[code]](https://github.com/facebookresearch/fairseq/blob/main/fairseq/modules/espnet_multihead_attention.py#L20-L108)
I also confirmed that it is training.


1. math.sqrt(dim) -> math.sqrt(d_head)
2. Add relative positional encoding module
3. Fix  `_relative_shift` method
       -  input : `B X n_head X T X 2T-1`
       - output : `B X n_head X T X T`